### PR TITLE
Added Os to CFLAGS

### DIFF
--- a/libhwcomposer/Android.mk
+++ b/libhwcomposer/Android.mk
@@ -13,6 +13,9 @@ LOCAL_SHARED_LIBRARIES        := $(common_libs) libEGL liboverlay \
                                  libdl libmemalloc libqservice libsync \
                                  libbinder libmedia libvirtual libskia
 LOCAL_CFLAGS                  := $(common_flags) -DLOG_TAG=\"qdhwcomposer\"
+
+#Unhide this string only if you compiling with O3 flag 
+#LOCAL_CFLAGS += -Os
 LOCAL_ADDITIONAL_DEPENDENCIES := $(common_deps)
 LOCAL_SRC_FILES               := hwc.cpp          \
                                  hwc_utils.cpp    \


### PR DESCRIPTION
Using plain -O3 causes compilation error
So by adding the Os to the CFLAGS seems to solve the compilation error
